### PR TITLE
Add a filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,9 @@ Recent history favors short, imperative subjects (`Remove unused action`, `Updat
 
 ## Deployment & Optimization
 Deployments run from `.github/workflows/main.yml`, installing Ruby 3.4 and Node 18 before minifying with `csso` and `terser` for GitHub Pages. Avoid committing pre-minified files; let the workflow handle optimization. If asset paths change, update the workflow scan paths and flag the tweak in your PR.
+
+## Agent Notes
+- Project filters now build from `_includes/projects/projects.html`: project cards expose `data-labels` (pipe-delimited + JSON fallback) and badges pass `interactive=true` when filters are enabled. Keep both attributes in sync when editing cards.
+- Filtering UI pulls tech colors through the existing contrast helpers; `css/contrast-utils.css` is loaded globally, so any new badge styles should keep the `badge-standard-contrast` variables intact.
+- Buttons only render for labels with more than one project unless whitelisted via `_data/project_filter_whitelist.yml` (currently TypeScript, Cloudflare Workers, Swift). Update the list to surface single-project filters.
+- `js/project-cards.js` relies on being loaded on every page; avoid moving that script tag back inside the home-page guard. Filter logic defaults to AND matching across active labels.

--- a/_data/project_filter_whitelist.yml
+++ b/_data/project_filter_whitelist.yml
@@ -1,0 +1,3 @@
+- typescript
+- cloudflare workers
+- swift

--- a/_includes/badge.html
+++ b/_includes/badge.html
@@ -12,8 +12,15 @@
   - Support for both light and dark modes
 {%- endcomment -%}
 
-{%- assign stripped_label = include.label | strip | downcase -%}
-{%- assign tech_info = site.data.tech_themes[stripped_label] -%}
+{%- assign label_text = include.label | strip -%}
+{%- assign normalized_label = label_text | downcase -%}
+{%- assign tech_info = site.data.tech_themes[normalized_label] -%}
+{%- assign is_interactive = include.interactive -%}
+{%- if is_interactive == true or is_interactive == 'true' -%}
+  {%- assign is_interactive = true -%}
+{%- else -%}
+  {%- assign is_interactive = false -%}
+{%- endif -%}
 
 {%- if tech_info and tech_info != empty -%}
   {%- assign standard_color = tech_info.color | ensure_contrast_standard -%}
@@ -25,23 +32,59 @@
   {%- assign needs_standard_dark = tech_info.color | needs_contrast_adjustment_dark_standard -%}
   {%- assign needs_high_dark = tech_info.color | needs_contrast_adjustment_dark_high -%}
   
+  {%- capture badge_inner -%}
+    <picture class="align-middle me-0" style="height: 1em; width: 1em;">
+      <source media="(prefers-color-scheme: dark) and (prefers-contrast: more)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ high_color_dark | remove_first: '#' }}">
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ standard_color_dark | remove_first: '#' }}">
+      <source media="(prefers-contrast: more)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ high_color | remove_first: '#' }}">
+      <img src="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ standard_color | remove_first: '#' }}" class="badge-icon" style="height: 1em; width: 1em;" alt="{{ tech_info.icon }} icon" loading="lazy" />
+    </picture>
+    {{ label_text }}
+  {%- endcapture -%}
+
   {%- if needs_standard or needs_high or needs_standard_dark or needs_high_dark -%}
-    <span class="badge rounded-pill me-1 badge-standard-contrast"
-      style="--badge-standard-color: {{ standard_color }}; --badge-high-color: {{ high_color }}; --badge-original-color: {{ tech_info.color }}; --badge-standard-dark-color: {{ standard_color_dark }}; --badge-high-dark-color: {{ high_color_dark }}; background-color: transparent; border: 1px solid {{ standard_color }}; color: {{ standard_color }};">
-        <picture class="align-middle me-0" style="height: 1em; width: 1em;">
-          <source media="(prefers-color-scheme: dark) and (prefers-contrast: more)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ high_color_dark | remove_first: '#' }}">
-          <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ standard_color_dark | remove_first: '#' }}">
-          <source media="(prefers-contrast: more)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ high_color | remove_first: '#' }}">
-          <img src="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ standard_color | remove_first: '#' }}" class="badge-icon" style="height: 1em; width: 1em;" alt="{{ tech_info.icon }} icon" loading="lazy" />
-        </picture>
-      {{ include.label }}
-    </span>
+    {%- if is_interactive -%}
+      <button type="button"
+              class="badge rounded-pill me-1 badge-standard-contrast badge-button"
+              data-project-badge
+              data-label="{{ normalized_label | escape }}"
+              data-label-display="{{ label_text | escape }}"
+              style="--badge-standard-color: {{ standard_color }}; --badge-high-color: {{ high_color }}; --badge-original-color: {{ tech_info.color }}; --badge-standard-dark-color: {{ standard_color_dark }}; --badge-high-dark-color: {{ high_color_dark }}; background-color: transparent; border: 1px solid {{ standard_color }}; color: {{ standard_color }};">
+        {{ badge_inner | strip }}
+      </button>
+    {%- else -%}
+      <span class="badge rounded-pill me-1 badge-standard-contrast"
+        style="--badge-standard-color: {{ standard_color }}; --badge-high-color: {{ high_color }}; --badge-original-color: {{ tech_info.color }}; --badge-standard-dark-color: {{ standard_color_dark }}; --badge-high-dark-color: {{ high_color_dark }}; background-color: transparent; border: 1px solid {{ standard_color }}; color: {{ standard_color }};">
+        {{ badge_inner | strip }}
+      </span>
+    {%- endif -%}
   {%- else -%}
-    <span class="badge rounded-pill me-1" style="background-color: transparent; border: 1px solid {{ tech_info.color }}; color: {{ tech_info.color }};">
-        <img src="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ tech_info.color | remove_first: '#' }}" class="align-middle me-0" style="height: 1em; width: 1em;" alt="{{ tech_info.icon }} icon" loading="lazy" />
-      {{ include.label }}
-    </span>
+    {%- if is_interactive -%}
+      <button type="button"
+              class="badge rounded-pill me-1 badge-button"
+              data-project-badge
+              data-label="{{ normalized_label | escape }}"
+              data-label-display="{{ label_text | escape }}"
+              style="background-color: transparent; border: 1px solid {{ tech_info.color }}; color: {{ tech_info.color }};">
+        {{ badge_inner | strip }}
+      </button>
+    {%- else -%}
+      <span class="badge rounded-pill me-1" style="background-color: transparent; border: 1px solid {{ tech_info.color }}; color: {{ tech_info.color }};">
+        {{ badge_inner | strip }}
+      </span>
+    {%- endif -%}
   {%- endif -%}
 {%- else -%}
-  <span style="background-color: var(--tf-pill-bg)" class="badge rounded-pill me-1">{{ include.label }}</span>
+  {%- if is_interactive -%}
+    <button type="button"
+            class="badge rounded-pill me-1 badge-button"
+            data-project-badge
+            data-label="{{ normalized_label | escape }}"
+            data-label-display="{{ label_text | escape }}"
+            style="background-color: var(--tf-pill-bg); border: none; color: inherit;">
+      {{ label_text }}
+    </button>
+  {%- else -%}
+    <span style="background-color: var(--tf-pill-bg)" class="badge rounded-pill me-1">{{ label_text }}</span>
+  {%- endif -%}
 {%- endif -%}

--- a/_includes/projects/project-card.html
+++ b/_includes/projects/project-card.html
@@ -1,3 +1,27 @@
+{%- assign card_labels = include.page.labels -%}
+{%- if card_labels -%}
+  {%- assign card_labels_json = card_labels | jsonify -%}
+  {%- assign card_labels_joined = "" -%}
+  {%- for card_label in card_labels -%}
+    {%- assign trimmed_card_label = card_label | strip -%}
+    {%- if trimmed_card_label != "" -%}
+      {%- if card_labels_joined == "" -%}
+        {%- assign card_labels_joined = trimmed_card_label -%}
+      {%- else -%}
+        {%- assign card_labels_joined = card_labels_joined | append: "||" | append: trimmed_card_label -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- else -%}
+  {%- assign card_labels_json = "[]" -%}
+  {%- assign card_labels_joined = "" -%}
+{%- endif -%}
+
+{%- assign badges_interactive = false -%}
+{%- if include.filters_enabled == true or include.filters_enabled == 'true' -%}
+  {%- assign badges_interactive = true -%}
+{%- endif -%}
+
 {%- if page.projecturl -%}
   {%- assign card_link = page.projecturl -%}
   {%- assign card_text = "Project Site" -%}
@@ -5,7 +29,12 @@
   {%- assign card_link = site.baseurl | append: include.page.url -%}
   {%- assign card_text = "Read More" -%}
 {%- endif -%}
-<div class="card mb-3 position-relative">
+<div class="card mb-3 position-relative"
+     data-project-card
+     data-project-title="{{ include.page.title | escape }}"
+     data-project-url="{{ card_link | escape }}"
+     data-labels="{{ card_labels_joined | escape }}"
+     data-labels-json='{{ card_labels_json | escape }}'>
   <div class="row g-0">
     <div class="col-md-4 col-lg-3 col-xxl-2 project-image-container{% if site.data.project_image_data[include.page.title] and site.data.project_image_data[include.page.title].is_wide %} wide{% endif %}">
       
@@ -26,7 +55,7 @@
         <p class="card-text">{{ include.page.summary }}</p>
         <p>
           {% for label in include.page.labels %}
-            {% include badge.html label=label %}
+            {% include badge.html label=label interactive=badges_interactive %}
           {% endfor %}
         </p>
       </div>

--- a/_includes/projects/projects.html
+++ b/_includes/projects/projects.html
@@ -6,24 +6,120 @@
       </div>
     </div>
 
+    {% assign project_pages = site.pages | where: "type", "project" | project_sort %}
+    {% assign delimiter = "||" %}
+    {% assign collected_labels = "" %}
+    {% assign not_draft = 0 %}
+    {% for page in project_pages %}
+      {% unless page.draft %}
+        {% assign not_draft = not_draft | plus: 1 %}
+        {% if page.labels %}
+          {% for raw_label in page.labels %}
+            {% assign label_trimmed = raw_label | strip %}
+            {% if label_trimmed != "" %}
+              {% assign collected_labels = collected_labels | append: label_trimmed | append: delimiter %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endunless %}
+    {% endfor %}
+
+    {% assign unique_labels = collected_labels | split: delimiter | uniq | sort %}
+    {% assign usable_labels = "" %}
+    {% for uniq_label in unique_labels %}
+      {% assign trimmed_unique = uniq_label | strip %}
+      {% if trimmed_unique != "" %}
+        {% if usable_labels == "" %}
+          {% assign usable_labels = trimmed_unique %}
+        {% else %}
+          {% assign usable_labels = usable_labels | append: delimiter | append: trimmed_unique %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+
+    {% assign filters_enabled = false %}
+    {% if include.limit == nil and usable_labels != "" %}
+      {% assign filters_enabled = true %}
+      {% assign filter_labels = usable_labels | split: delimiter %}
+    {% endif %}
+
+    {% if filters_enabled %}
+      {% assign filter_whitelist = site.data.project_filter_whitelist %}
+      {% if filter_whitelist == nil %}
+        {% assign filter_whitelist = '' | split: '|' %}
+      {% endif %}
+      <div class="project-filter-toolbar" data-project-filter data-total-projects="{{ not_draft }}">
+        <div class="project-filter-buttons" data-filter-group>
+          {% for filter_label in filter_labels %}
+            {% assign normalized_label = filter_label | strip | downcase %}
+            {% assign label_count = 0 %}
+            {% for page in project_pages %}
+              {% unless page.draft %}
+                {% if page.labels and page.labels contains filter_label %}
+                  {% assign label_count = label_count | plus: 1 %}
+                {% endif %}
+              {% endunless %}
+            {% endfor %}
+            {% assign allow_single = false %}
+            {% if filter_whitelist contains normalized_label %}
+              {% assign allow_single = true %}
+            {% endif %}
+            {% if label_count > 1 or allow_single %}
+              {% assign tech_info = site.data.tech_themes[normalized_label] %}
+              {% assign button_classes = "project-filter-button" %}
+              {% assign button_style = "" %}
+              {% capture icon_markup %}{% endcapture %}
+              {% if tech_info and tech_info != empty %}
+                {% assign standard_color = tech_info.color | ensure_contrast_standard %}
+                {% assign high_color = tech_info.color | ensure_contrast_high %}
+                {% assign standard_color_dark = tech_info.color | ensure_contrast_dark_standard %}
+                {% assign high_color_dark = tech_info.color | ensure_contrast_dark_high %}
+                {% capture icon_markup %}
+                  <picture class="project-filter-icon">
+                    <source media="(prefers-color-scheme: dark) and (prefers-contrast: more)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ high_color_dark | remove_first: '#' }}">
+                    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ standard_color_dark | remove_first: '#' }}">
+                    <source media="(prefers-contrast: more)" srcset="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ high_color | remove_first: '#' }}">
+                    <img src="https://cdn.simpleicons.org/{{ tech_info.icon }}/{{ standard_color | remove_first: '#' }}" alt="" aria-hidden="true">
+                  </picture>
+                {% endcapture %}
+                {% capture button_style %}
+--filter-border-color: {{ standard_color }};--filter-color: {{ standard_color }};--filter-hover-color: {{ high_color }};--filter-active-color: {{ standard_color }};--filter-text-color: #fff;
+                {% endcapture %}
+                {% assign button_style = button_style | strip | strip_newlines %}
+                {% assign button_classes = button_classes | append: " project-filter-button--has-color" %}
+              {% endif %}
+              <button type="button"
+                      class="{{ button_classes }}"
+                      data-filter-button
+                      data-label="{{ normalized_label | escape }}"
+                      data-label-display="{{ filter_label | escape }}"
+                      data-count="{{ label_count }}"
+                      aria-pressed="false"
+                      aria-label="{{ filter_label | escape }} ({{ label_count }} project{% if label_count != 1 %}s{% endif %})"
+                      {% unless button_style == "" %}style="{{ button_style }}"{% endunless %}>
+                {{ icon_markup | strip }}
+                <span class="project-filter-label">{{ filter_label }}</span>
+              </button>
+            {% endif %}
+          {% endfor %}
+        </div>
+        <div class="project-filter-actions">
+          <button type="button" class="project-filter-clear" data-filter-clear hidden>Clear filters</button>
+          <p class="project-filter-status small text-muted" aria-live="polite" data-filter-status></p>
+        </div>
+      </div>
+    {% endif %}
+
     <div class="vstack gap-3">
-      {% assign project_pages = site.pages | where: "type", "project" | project_sort %}
       {% for page in project_pages %}
         {% unless page.draft %}
-          {% include projects/project-card.html page=page %}
+          {% include projects/project-card.html page=page filters_enabled=filters_enabled %}
         {% endunless %}
         {% if forloop.index == include.limit %}
           {% break %}
         {% endif %}
       {% endfor %}
     </div>
-
-    {% assign not_draft = 0 %}
-      {% for page in project_pages %}
-      {% unless page.draft %}
-        {% assign not_draft = not_draft | plus: 1 %}
-      {% endunless %}
-    {% endfor %}
 
     {% if not_draft > include.limit %}
       <p class="text-center pt-4"><a href="{{ site.baseurl}}/projects/">See all {{ not_draft }} projects</a></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,11 +47,11 @@
     <script defer src="{{ site.baseurl }}/js/music-status.js"></script>
     <script defer src="{{ site.baseurl }}/js/profile-icons.js"></script>
     <script defer src="{{ site.baseurl }}/js/name-cycler.js"></script>
-    <script defer src="{{ site.baseurl }}/js/project-cards.js"></script>
     <!-- Add other home-page-specific preloads here -->
     <link rel="stylesheet" href="{{ site.baseurl}}/css/profile-icons.css">
-    <link rel="stylesheet" href="{{ site.baseurl}}/css/contrast-utils.css">
     {% endif %}
+    <script defer src="{{ site.baseurl }}/js/project-cards.js"></script>
+    <link rel="stylesheet" href="{{ site.baseurl}}/css/contrast-utils.css">
     
     <link rel="shortcut icon" href="{{ '/favicon.ico' | prepend: site.baseurl }}">
     

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -134,10 +134,118 @@ a {
   background: transparent;
 }
 
+.badge-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.badge-button:focus-visible {
+  outline: 2px solid var(--bs-link-color);
+  outline-offset: 2px;
+}
+
+.badge-button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.badge-button[disabled] {
+  cursor: default;
+  opacity: 0.7;
+}
+
 /* Simplify the styling of the bottom of Essay cards. */
 .card-footer {
   background-color: var(--bs-white);
   border-top: none;
+}
+
+.project-filter-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.project-filter-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.project-filter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.project-filter-button {
+  border: 1px solid var(--filter-border-color, var(--bs-gray-400));
+  background: transparent;
+  color: var(--filter-color, inherit);
+  border-radius: 9999px;
+  padding: 0.35rem 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.project-filter-button:hover,
+.project-filter-button:focus-visible {
+  background-color: var(--filter-hover-color, rgba(0, 0, 0, 0.05));
+  color: var(--filter-text-color, inherit);
+  outline: none;
+}
+
+.project-filter-button.is-active {
+  background-color: var(--filter-active-color, var(--bs-gray-900));
+  color: var(--filter-text-color, var(--bs-white));
+  border-color: var(--filter-active-color, var(--bs-gray-900));
+}
+
+.project-filter-icon {
+  display: inline-flex;
+  height: 1em;
+  width: 1em;
+}
+
+.project-filter-icon img {
+  height: 1em;
+  width: 1em;
+}
+
+.project-filter-label {
+  line-height: 1.2;
+}
+
+.project-filter-clear {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--bs-link-color);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.project-filter-clear:hover,
+.project-filter-clear:focus-visible {
+  text-decoration: underline;
+}
+
+.project-filter-status {
+  margin: 0;
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 /* Project card image handling */

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -95,7 +95,20 @@ a {
   color: inherit;
   cursor: pointer;
   border-radius: 9999px;
-  transition: transform 0.2s, background-color 0.2s;
+  opacity: 0;
+  transform: scale(0.96);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+}
+
+.music-status-container:hover .music-refresh-button,
+.music-status-container:focus-within .music-refresh-button,
+.music-status-header:hover .music-refresh-button,
+.music-status-header:focus-within .music-refresh-button,
+.music-refresh-button:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(1);
 }
 
 .music-refresh-button:hover {

--- a/js/project-cards.js
+++ b/js/project-cards.js
@@ -13,10 +13,226 @@
       }
     });
   }
-  if (document.readyState === 'complete') {
+
+  function parseLabels(card) {
+    if (!card) {
+      return [];
+    }
+    var joined = card.getAttribute('data-labels');
+    if (joined && joined.length) {
+      return joined.split('||').map(function(label) {
+        return label.trim();
+      }).filter(function(label) {
+        return label.length > 0;
+      });
+    }
+    var jsonAttr = card.getAttribute('data-labels-json');
+    if (jsonAttr) {
+      try {
+        var parsed = JSON.parse(jsonAttr);
+        if (Array.isArray(parsed)) {
+          return parsed;
+        }
+      } catch (err) {
+        console.warn('Unable to parse project labels', err);
+      }
+    }
+    return [];
+  }
+
+  function setupFiltering() {
+    var toolbar = document.querySelector('[data-project-filter]');
+    if (!toolbar) {
+      return;
+    }
+
+    var cards = Array.prototype.slice.call(document.querySelectorAll('[data-project-card]'));
+    if (!cards.length) {
+      return;
+    }
+
+    var filterButtons = Array.prototype.slice.call(toolbar.querySelectorAll('[data-filter-button]'));
+    if (!filterButtons.length) {
+      return;
+    }
+
+    var clearButton = toolbar.querySelector('[data-filter-clear]');
+    var statusEl = toolbar.querySelector('[data-filter-status]');
+    var totalProjectsAttr = toolbar.getAttribute('data-total-projects');
+    var totalProjects = parseInt(totalProjectsAttr, 10);
+    if (isNaN(totalProjects) || totalProjects < 0) {
+      totalProjects = cards.length;
+    }
+
+    var labelNameMap = Object.create(null);
+    filterButtons.forEach(function(button) {
+      var labelDisplay = button.getAttribute('data-label-display') || button.textContent.trim();
+      var normalized = (button.getAttribute('data-label') || labelDisplay).toLowerCase();
+      button.setAttribute('data-label', normalized);
+      labelNameMap[normalized] = labelDisplay;
+    });
+
+    var activeFilters = [];
+
+    function isActive(label) {
+      return activeFilters.indexOf(label) !== -1;
+    }
+
+    function addFilter(label) {
+      if (!label) {
+        return;
+      }
+      if (!isActive(label)) {
+        activeFilters.push(label);
+      }
+    }
+
+    function removeFilter(label) {
+      var index = activeFilters.indexOf(label);
+      if (index !== -1) {
+        activeFilters.splice(index, 1);
+      }
+    }
+
+    function clearFilters() {
+      activeFilters.length = 0;
+    }
+
+    function updateControls(matchedCount) {
+      filterButtons.forEach(function(button) {
+        var label = button.getAttribute('data-label');
+        var active = isActive(label);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+        button.classList.toggle('is-active', active);
+      });
+
+      if (clearButton) {
+        clearButton.hidden = activeFilters.length === 0;
+      }
+
+      if (!statusEl) {
+        return;
+      }
+
+      if (activeFilters.length === 0) {
+        statusEl.textContent = totalProjects + ' project' + (totalProjects === 1 ? '' : 's') + ' available';
+      } else {
+        var readable = [];
+        for (var idx = 0; idx < activeFilters.length; idx += 1) {
+          var activeLabel = activeFilters[idx];
+          readable.push(labelNameMap[activeLabel] || activeLabel);
+        }
+        statusEl.textContent = matchedCount + ' match' + (matchedCount === 1 ? '' : 'es') + ' for ' + readable.join(', ');
+      }
+    }
+
+    function filterCards() {
+      var matchedCount = 0;
+      cards.forEach(function(card) {
+        var labels = parseLabels(card).map(function(label) {
+          return String(label).toLowerCase();
+        });
+        var matches = true;
+        if (activeFilters.length > 0) {
+          for (var idx = 0; idx < activeFilters.length; idx += 1) {
+            var required = activeFilters[idx];
+            if (labels.indexOf(required) === -1) {
+              matches = false;
+              break;
+            }
+          }
+        }
+        card.classList.toggle('is-hidden', !matches);
+        if (matches) {
+          matchedCount += 1;
+        }
+      });
+
+      updateControls(matchedCount);
+    }
+
+    function toggleFilter(label) {
+      if (!label) {
+        return;
+      }
+      if (isActive(label)) {
+        removeFilter(label);
+      } else {
+        addFilter(label);
+      }
+      filterCards();
+    }
+
+    function setSingleFilter(label) {
+      if (!label) {
+        return;
+      }
+      if (activeFilters.length === 1 && isActive(label)) {
+        clearFilters();
+      } else {
+        clearFilters();
+        addFilter(label);
+      }
+      filterCards();
+    }
+
+    filterButtons.forEach(function(button) {
+      button.addEventListener('click', function() {
+        toggleFilter(button.getAttribute('data-label'));
+      });
+    });
+
+    if (clearButton) {
+      clearButton.addEventListener('click', function() {
+        if (activeFilters.length === 0) {
+          return;
+        }
+        clearFilters();
+        filterCards();
+        var firstButton = filterButtons[0];
+        if (firstButton) {
+          firstButton.focus();
+        }
+      });
+    }
+
+    var badgeButtons = Array.prototype.slice.call(document.querySelectorAll('[data-project-badge]'));
+    badgeButtons.forEach(function(button) {
+      var normalized = (button.getAttribute('data-label') || '').toLowerCase();
+      var displayLabel = button.getAttribute('data-label-display') || button.textContent.trim();
+      if (normalized) {
+        labelNameMap[normalized] = displayLabel;
+      }
+      button.addEventListener('click', function() {
+        if (!normalized) {
+          return;
+        }
+        setSingleFilter(normalized);
+        var targetButton = null;
+        for (var idx = 0; idx < filterButtons.length; idx += 1) {
+          if (filterButtons[idx].getAttribute('data-label') === normalized) {
+            targetButton = filterButtons[idx];
+            break;
+          }
+        }
+        if (targetButton) {
+          targetButton.focus();
+        }
+      });
+    });
+
+    filterCards();
+  }
+
+  function initialize() {
     applyCrop();
+    setupFiltering();
+  }
+
+  if (document.readyState === 'complete') {
+    initialize();
   } else {
-    window.addEventListener('load', applyCrop);
+    window.addEventListener('load', initialize);
   }
   window.matchMedia('(min-width: 768px)').addEventListener('change', applyCrop);
 })();


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul to the project filtering and badge UI on the Projects page, making filters interactive, improving accessibility, and ensuring better maintainability. Key changes include enabling dynamic filtering based on project labels, interactive badge rendering, and global loading of necessary scripts and styles. The update also introduces a whitelist for single-project filters and refines the CSS to support the new interactive elements.

**Project Filtering and UI Enhancements**

* Added dynamic project filter toolbar: Projects can now be filtered interactively by their labels, with filter buttons rendered for labels associated with multiple projects or whitelisted single-project labels (`typescript`, `cloudflare workers`, `swift`). The filter UI is accessible and uses color contrast helpers for tech badges. (`[[1]](diffhunk://#diff-17f0a1b6e13c63cab261cf5e3402a514272a594a9578e717b11bc199da29d823L9-R122)`, `[[2]](diffhunk://#diff-16d8e296dbcabc305fac5c31632f15f1931d2b51cd3d34fc8589f28065224ba3R1-R3)`, `[[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R23-R28)`)
* Project cards now expose their labels as both a pipe-delimited string and JSON via `data-labels` and `data-labels-json` attributes, supporting the new filter logic and UI. (`[_includes/projects/project-card.htmlR1-R37](diffhunk://#diff-3d0e7c9ce5f9dd0bebff4f558d08ed91aaf160a62c49788862c2afc5a92499e7R1-R37)`)
* Badges on project cards are now interactive when filters are enabled, rendered as buttons with appropriate ARIA and data attributes for accessibility and filter integration. (`[[1]](diffhunk://#diff-274fedbb2a6c5e5191a0ac3afd0d24212b686691c42b3ff6087c321210e71835L15-R23)`, `[[2]](diffhunk://#diff-274fedbb2a6c5e5191a0ac3afd0d24212b686691c42b3ff6087c321210e71835L28-R89)`, `[[3]](diffhunk://#diff-3d0e7c9ce5f9dd0bebff4f558d08ed91aaf160a62c49788862c2afc5a92499e7L29-R58)`)

**Global Script and Style Loading**

* Ensured that `js/project-cards.js` and `css/contrast-utils.css` are loaded globally on all pages, not just the homepage, to support interactive filtering and badge contrast everywhere. (`[_layouts/default.htmlL50-R54](diffhunk://#diff-907a69846a1f6b238f1c43199984197d12c7eab26f3c3adcd45d628b26644950L50-R54)`)

**Styling and Accessibility Improvements**

* Added new CSS classes for interactive badges (`.badge-button`) and filter buttons (`.project-filter-button`), with focus-visible outlines, hover effects, and active states for improved accessibility and user experience. Also included styles for the filter toolbar and clear button. (`[css/techfolio-theme/default.cssR137-R250](diffhunk://#diff-d083da9932cc317fc17f0226b5269f3fe69f2350ca0fec7fc60c569f33d1d35bR137-R250)`)
* Improved music status button visibility and interaction on hover/focus for consistency with other interactive elements. (`[css/techfolio-theme/default.cssL98-R111](diffhunk://#diff-d083da9932cc317fc17f0226b5269f3fe69f2350ca0fec7fc60c569f33d1d35bL98-R111)`)